### PR TITLE
fix:allow workshop 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 skyfield
 ovos-date-parser>=0.0.3,<1.0.0
-ovos-workshop>=0.0.12,<3.0.0
+ovos-workshop>=0.0.12,<4.0.0
 ovos-bus-client>=1.0.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos-workshop` package to allow for newer versions, enhancing compatibility and access to features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->