### PR TITLE
Add fr-fr locale

### DIFF
--- a/locale/fr-fr/how_many.voc
+++ b/locale/fr-fr/how_many.voc
@@ -1,0 +1,3 @@
+combien
+nombre
+total

--- a/locale/fr-fr/iss.voc
+++ b/locale/fr-fr/iss.voc
@@ -1,0 +1,4 @@
+I S S
+ISS
+station spatiale
+station spatiale internationale

--- a/locale/fr-fr/location.current.dialog
+++ b/locale/fr-fr/location.current.dialog
@@ -1,0 +1,3 @@
+L'ISS se trouve au-dessus de {toponym}, à la latitude {latitude} et à la longitude {longitude}.
+La station spatiale internationale est actuellement au-dessus de {toponym}, à la latitude {latitude} et à la longitude {longitude}.
+La station spatiale est à la latitude {latitude} et à la longitude {longitude}, au-dessus de {toponym}.

--- a/locale/fr-fr/location.unknown.dialog
+++ b/locale/fr-fr/location.unknown.dialog
@@ -1,0 +1,2 @@
+L'ISS est actuellement à la latitude {latitude} et à la longitude {longitude}, mais je ne peux pas associer cette position à un lieu connu.
+La station spatiale est à la latitude {latitude} et à la longitude {longitude}, mais je ne sais pas au-dessus de quel endroit elle se trouve.

--- a/locale/fr-fr/location.when.dialog
+++ b/locale/fr-fr/location.when.dialog
@@ -1,0 +1,3 @@
+L'ISS passera au-dessus de {toponym} dans {duration}.
+La station spatiale internationale sera au-dessus de {toponym} dans {duration}.
+La station spatiale passera à proximité de {toponym} dans {duration}.

--- a/locale/fr-fr/number.dialog
+++ b/locale/fr-fr/number.dialog
@@ -1,0 +1,3 @@
+Il y a {number} personnes à bord de la station spatiale.
+{number} personnes sont actuellement à bord de l'ISS.
+Il y a {number} personnes en orbite à bord de la station spatiale internationale.

--- a/locale/fr-fr/onboard.voc
+++ b/locale/fr-fr/onboard.voc
@@ -1,0 +1,3 @@
+à bord
+dans la
+sur la

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,17 @@
+{
+  "skill_id": "ovos-skill-iss-location.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-iss-location",
+  "name": "Suivi de l'ISS",
+  "description": "Suivre la position de l'ISS",
+  "examples": [
+    "Où est l'ISS",
+    "Qui est à bord de la station spatiale",
+    "Quand l'ISS passera au-dessus de moi",
+    "Parle-moi de l'ISS",
+    "Combien de personnes sont à bord de la station spatiale"
+  ],
+  "tags": [
+    "Trivia",
+    "space"
+  ]
+}

--- a/locale/fr-fr/visible_for.dialog
+++ b/locale/fr-fr/visible_for.dialog
@@ -1,0 +1,2 @@
+Elle sera visible pendant {duration}.
+Vous pourrez la voir pendant {duration}.

--- a/locale/fr-fr/when_iss.intent
+++ b/locale/fr-fr/when_iss.intent
@@ -1,0 +1,9 @@
+quand l'ISS passera au-dessus de moi
+quand l'ISS passera au-dessus de nous
+quand l'ISS passera au-dessus
+quand la station spatiale passera au-dessus de moi
+quand la station spatiale passera au-dessus de nous
+quand la station spatiale passera au-dessus
+quand la station spatiale internationale passera au-dessus de moi
+quand la station spatiale internationale passera au-dessus de nous
+quand la station spatiale internationale passera au-dessus

--- a/locale/fr-fr/where_iss.intent
+++ b/locale/fr-fr/where_iss.intent
@@ -1,0 +1,8 @@
+où est l'ISS
+où se trouve l'ISS
+où est la station spatiale
+où se trouve la station spatiale
+où est la station spatiale internationale
+où se trouve la station spatiale internationale
+donne-moi la position de l'ISS
+quelle est la position de l'ISS

--- a/locale/fr-fr/who.dialog
+++ b/locale/fr-fr/who.dialog
@@ -1,0 +1,3 @@
+Les personnes actuellement à bord de la station spatiale internationale sont {people}.
+Voici les personnes à bord de l'ISS : {people}.
+{people} sont actuellement à bord de la station spatiale.

--- a/locale/fr-fr/who.voc
+++ b/locale/fr-fr/who.voc
@@ -1,0 +1,4 @@
+astronautes
+personne
+personnes
+qui

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,0 +1,30 @@
+{
+    "location.current.dialog": [
+        "L'ISS se trouve au-dessus de {toponym}, \u00e0 la latitude {latitude} et \u00e0 la longitude {longitude}.",
+        "La station spatiale internationale est actuellement au-dessus de {toponym}, \u00e0 la latitude {latitude} et \u00e0 la longitude {longitude}.",
+        "La station spatiale est \u00e0 la latitude {latitude} et \u00e0 la longitude {longitude}, au-dessus de {toponym}."
+    ],
+    "location.unknown.dialog": [
+        "L'ISS est actuellement \u00e0 la latitude {latitude} et \u00e0 la longitude {longitude}, mais je ne peux pas associer cette position \u00e0 un lieu connu.",
+        "La station spatiale est \u00e0 la latitude {latitude} et \u00e0 la longitude {longitude}, mais je ne sais pas au-dessus de quel endroit elle se trouve."
+    ],
+    "location.when.dialog": [
+        "L'ISS passera au-dessus de {toponym} dans {duration}.",
+        "La station spatiale internationale sera au-dessus de {toponym} dans {duration}.",
+        "La station spatiale passera \u00e0 proximit\u00e9 de {toponym} dans {duration}."
+    ],
+    "number.dialog": [
+        "Il y a {number} personnes \u00e0 bord de la station spatiale.",
+        "{number} personnes sont actuellement \u00e0 bord de l'ISS.",
+        "Il y a {number} personnes en orbite \u00e0 bord de la station spatiale internationale."
+    ],
+    "visible_for.dialog": [
+        "Elle sera visible pendant {duration}.",
+        "Vous pourrez la voir pendant {duration}."
+    ],
+    "who.dialog": [
+        "Les personnes actuellement \u00e0 bord de la station spatiale internationale sont {people}.",
+        "Voici les personnes \u00e0 bord de l'ISS : {people}.",
+        "{people} sont actuellement \u00e0 bord de la station spatiale."
+    ]
+}

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,0 +1,23 @@
+{
+    "when_iss.intent": [
+        "quand l'ISS passera au-dessus de moi",
+        "quand l'ISS passera au-dessus de nous",
+        "quand l'ISS passera au-dessus",
+        "quand la station spatiale passera au-dessus de moi",
+        "quand la station spatiale passera au-dessus de nous",
+        "quand la station spatiale passera au-dessus",
+        "quand la station spatiale internationale passera au-dessus de moi",
+        "quand la station spatiale internationale passera au-dessus de nous",
+        "quand la station spatiale internationale passera au-dessus"
+    ],
+    "where_iss.intent": [
+        "o\u00f9 est l'ISS",
+        "o\u00f9 se trouve l'ISS",
+        "o\u00f9 est la station spatiale",
+        "o\u00f9 se trouve la station spatiale",
+        "o\u00f9 est la station spatiale internationale",
+        "o\u00f9 se trouve la station spatiale internationale",
+        "donne-moi la position de l'ISS",
+        "quelle est la position de l'ISS"
+    ]
+}

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,0 +1,24 @@
+{
+    "how_many.voc": [
+        "combien",
+        "nombre",
+        "total"
+    ],
+    "iss.voc": [
+        "I S S",
+        "ISS",
+        "station spatiale",
+        "station spatiale internationale"
+    ],
+    "onboard.voc": [
+        "\u00e0 bord",
+        "dans la",
+        "sur la"
+    ],
+    "who.voc": [
+        "astronautes",
+        "personne",
+        "personnes",
+        "qui"
+    ]
+}


### PR DESCRIPTION
## Summary
- add a complete `fr-fr` locale tree matching `en-us`
- add the matching `translations/fr-fr` snapshot files
- localize the ISS prompts and spoken responses for French assistant use