### PR TITLE
chore(ovos-skill-iss-location): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 skyfield
 ovos-date-parser>=0.0.3,<1.0.0
-ovos-workshop>=8.0.0,<8.1.0
+ovos-workshop>=8.0.0,<9.0.0
 ovos-bus-client>=1.0.1


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0